### PR TITLE
Reverse subject rows sort order

### DIFF
--- a/web_client/js/InfoPage.js
+++ b/web_client/js/InfoPage.js
@@ -139,7 +139,7 @@ girder.views.monkeybrains_InfoPageWidget = girder.View.extend({
         subject_ids.sort(function (a, b) {
             var firstScanA = subjects[a].firstScanDays,
                 firstScanB = subjects[b].firstScanDays;
-            return (firstScanA > firstScanB) - (firstScanA < firstScanB);
+            return (firstScanA < firstScanB) - (firstScanA > firstScanB);
         });
         var longitude = {
             subject_ids: subject_ids,

--- a/web_client/stylesheets/longitude.styl
+++ b/web_client/stylesheets/longitude.styl
@@ -54,6 +54,9 @@
 .female-event:hover
     stroke-width 5
 
+.male-event:hover
+    stroke-width 4
+
 .birth 
     fill #8c510a
     stroke #8c510a


### PR DESCRIPTION
Martin had requested the sort order in the graph be reversed.  It will still sort by the normalized age of the first scan (i.e. number of days between birth and first scan), but will now sort oldest to youngest using this normalized age.

Also added a fix where circle events for males would slightly increase in radius on a mouseover.
