### PR TITLE
Update hardcoded download folder

### DIFF
--- a/web_client/templates/collection_infopage.jade
+++ b/web_client/templates/collection_infopage.jade
@@ -5,7 +5,7 @@
             .container
                 h1.page-title Macaque Neuro-Developmental Data
                 p A freely downloadable longitudinal database of more than 150 neonate macaque brain scans across 32 subjects
-                a.monkeybrains-download-dataset.btn.btn-primary(href="https://data.kitware.com/api/v1/folder/54b582d88d777f4362aa9cb5/download")
+                a.monkeybrains-download-dataset.btn.btn-primary(href="https://data.kitware.com/api/v1/folder/553e6db18d777f082b5918eb/download")
                     i.icon-download
                     | Download the full dataset
     .g-collection-infopage-markdown


### PR DESCRIPTION
There was an error with the scan_data folder at one point and it was recreated, but this link wasn't changed.  Clearly this should be more robust/less hard-coded, but this is the quickest solution.

@cpatrick PTAL.
