### PR TITLE
Use local node_modules directory to avoid dependency hell

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -3,6 +3,7 @@
 "description": "Provides a customized view of a longitudinal dataset stored in a community",
 "version": "0.1.1",
 "npm": {
+    "localNodeModules": true,
     "dependencies": {
         "d3": ">= 3.0.0 <4.0.0"
         }

--- a/web_client/longitude-d3.js
+++ b/web_client/longitude-d3.js
@@ -1,4 +1,4 @@
-import d3 from 'd3';
+import d3 from 'girder_plugins/monkeybrains/node/d3';
 /**
  * This longitudinal chart is based on the d3 gantt chart v2.0 originally
  * created by author Dimitry Kudrayvtsev.


### PR DESCRIPTION
One of girder's core packages (the datetime picker) has an upstream
depdendency (moment.js) that conflicts with an upstream dependency
on moment that is required in the older version of d3 used by the
monkeybrains plugin. We alleviate this by installing the package
locally to the plugin rather than into girder's node_modules.

@mgrauer if this looks good to you I'll merge and this will fix our build process on data.kitware.com